### PR TITLE
added warning print statements in base agent about deprecation

### DIFF
--- a/src/main/java/org/yourteamname/agents/BaseAgent.java
+++ b/src/main/java/org/yourteamname/agents/BaseAgent.java
@@ -45,6 +45,7 @@ public abstract class BaseAgent extends Agent {
         catch (FIPAException fe) {
             fe.printStackTrace();
         }
+        System.out.println("\nWARNING: getCurrentDay and getCurrentHour will be deprecated in future.\n");
     }
     
     /* This function removes the agent from yellow pages
@@ -57,6 +58,7 @@ public abstract class BaseAgent extends Agent {
         catch (FIPAException fe) {
             fe.printStackTrace();
         }
+        System.out.println("\nWARNING: getCurrentDay and getCurrentHour will be deprecated in future.\n");
     }
 
     /* This function sends finished message to clockAgent


### PR DESCRIPTION
**Added**

- warning print saying deprecation of the functions `getCurrentHour` and `getCurrentDay`

@argenos 