### PR TITLE
Timekeeper: Refactored peformative used to broadcast timestep

### DIFF
--- a/src/main/java/org/maas/agents/BaseAgent.java
+++ b/src/main/java/org/maas/agents/BaseAgent.java
@@ -123,7 +123,7 @@ public abstract class BaseAgent extends Agent {
         private MessageTemplate mt;
 
         public void action(){
-            this.mt = MessageTemplate.and(MessageTemplate.MatchPerformative(55),
+            this.mt = MessageTemplate.and(MessageTemplate.MatchPerformative(TimeKeeper.BROADCAST_TIMESTEP_PERFORMATIVE),
                     MessageTemplate.MatchSender(baseAgent.clockAgent));
             ACLMessage msg = myAgent.receive(this.mt);
             if (msg != null) {

--- a/src/main/java/org/maas/agents/TimeKeeper.java
+++ b/src/main/java/org/maas/agents/TimeKeeper.java
@@ -16,6 +16,12 @@ import jade.lang.acl.MessageTemplate;
 
 @SuppressWarnings("serial")
 public class TimeKeeper extends Agent{
+	/*
+	 * Defines a performative value outside the range of values defined in ACLMessage (-1 to 19)
+	 * so that TimeStep messages do not interfere with other communications
+	 */
+	public static final int BROADCAST_TIMESTEP_PERFORMATIVE = 55;
+	
 	private int currentTimeStep;
 	private int countAgentsReplied;
 	
@@ -63,7 +69,7 @@ public class TimeKeeper extends Agent{
             countAgentsReplied = agents.size();
             System.out.println(">>>>> " + currentTimeStep + " <<<<<");
             for (DFAgentDescription agent : agents) {
-                ACLMessage timeMessage = new ACLMessage(55);
+                ACLMessage timeMessage = new ACLMessage(BROADCAST_TIMESTEP_PERFORMATIVE);
                 timeMessage.addReceiver(agent.getName());
                 timeMessage.setContent(Integer.toString(currentTimeStep));
                 myAgent.send(timeMessage);


### PR DESCRIPTION
It's a minor refactoring to clarify the magic number (55) used in BaseAgent and TimeKeeper. Does not have any impact on any team repository. Fixes [issue 67](https://github.com/HBRS-MAAS/ws18-project-right-brothers/issues/67) in right_brothers repo.