### PR TITLE
Pass bakery id with conversation id for visualization

### DIFF
--- a/src/main/java/org/maas/agents/BaseAgent.java
+++ b/src/main/java/org/maas/agents/BaseAgent.java
@@ -2,6 +2,8 @@ package org.maas.agents;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.maas.utils.Time;
 
@@ -137,6 +139,19 @@ public abstract class BaseAgent extends Agent {
     			if(conversationId.matches(pattern)) {
 	    	    	msg.clearAllReceiver();
 	    	    	msg.addReceiver(visualisationAgent);
+	    	    	
+	    	    	// Add bakery id with conversation for baking request and packaged orders
+	    	    	if(!pattern.equals(visualizedMessages.get(1))) {
+	    	    		Matcher bakeryMatcher = Pattern.compile("^(\\w+)\\-(\\d+)\\-")
+	    	    				.matcher(msg.getSender().getLocalName());
+	    	    		
+	    	    		if(bakeryMatcher.lookingAt()) {
+	    	        		msg.setConversationId(
+	    	        				bakeryMatcher.group(1)+ "-" + bakeryMatcher.group(2) + "-" + msg.getConversationId()
+    	        				);
+	    	    		}
+	    	    	}
+	    	    	
 	    	    	this.send(msg);
 	    	    	
 	    	    	break;


### PR DESCRIPTION
Visualizer needs bakery id for the messages to visualize. For example, when visualizer receives a cooling-rack message it needs to trace which dough belonging to which bakery was used to make the baked products represented by the cooling-rack message.

Agents can pass the bakery id as part of conversation id but not all agents are doing so. So, as an alternate bakery name is being parsed from sender name and added to the conversation id.