### PR TITLE
Change default search limit for number of agents to 1000

### DIFF
--- a/src/main/java/org/maas/Start.java
+++ b/src/main/java/org/maas/Start.java
@@ -35,6 +35,9 @@ public class Start {
     public static List<String> buildCMD() {
         StringBuilder sb = new StringBuilder();
         List<String> cmd = new Vector<>();
+        
+        cmd.add("-jade_domain_df_maxresult");
+        cmd.add("10000");
 
         if(isHost) {
             cmd.add("-local-port");

--- a/src/main/java/org/maas/agents/TimeKeeper.java
+++ b/src/main/java/org/maas/agents/TimeKeeper.java
@@ -15,6 +15,7 @@ import jade.core.behaviours.*;
 import jade.domain.DFService;
 import jade.domain.FIPAException;
 import jade.domain.FIPAAgentManagement.DFAgentDescription;
+import jade.domain.FIPAAgentManagement.SearchConstraints;
 import jade.domain.FIPAAgentManagement.ServiceDescription;
 import jade.lang.acl.ACLMessage;
 import jade.lang.acl.MessageTemplate;
@@ -105,10 +106,12 @@ public class TimeKeeper extends Agent{
 	private List<DFAgentDescription> getAllAgents(){
 		DFAgentDescription template = new DFAgentDescription();
 		ServiceDescription sd = new ServiceDescription();
+		SearchConstraints getAll = new SearchConstraints();
+		getAll.setMaxResults(new Long(-1));
 //         sd.setName("JADE-bakery");
 		template.addServices(sd);
 		try {
-			DFAgentDescription[] result = DFService.search(this, template);
+			DFAgentDescription[] result = DFService.search(this, template, getAll);
 			return Arrays.asList(result);
 		}
 		catch (FIPAException fe) {


### PR DESCRIPTION
The default search limit for the number of agents that DF can search has to be increased from 100 since we have more number of agents with larger scenario files. With this pull request we increase the search limit to 10000.