### PR TITLE
Update the loading bay agent

### DIFF
--- a/src/main/java/org/maas/agents/LoadingBayAgent.java
+++ b/src/main/java/org/maas/agents/LoadingBayAgent.java
@@ -16,7 +16,6 @@ import jade.lang.acl.MessageTemplate;
 @SuppressWarnings("serial")
 public class LoadingBayAgent extends BaseAgent {
 	private JSONArray orderDetailsArray = new JSONArray();
-	private String readyOrderID = null;
 	private String bakeryGuid = "bakery-001";
 
 	private HashMap<String, HashMap<String, Integer>> productDatabase = new HashMap<>();
@@ -183,6 +182,11 @@ public class LoadingBayAgent extends BaseAgent {
 
 	private class PackagingPhaseMessageSender extends OneShotBehaviour {
 		private AID receivingAgent = null;
+		String orderID = null;
+		
+		public PackagingPhaseMessageSender(String id) {
+			this.orderID = id;
+		}
 
 		protected void findReceiver() {
 			DFAgentDescription template = new DFAgentDescription();
@@ -212,7 +216,7 @@ public class LoadingBayAgent extends BaseAgent {
 				ACLMessage msg = new ACLMessage(ACLMessage.INFORM);
 	
 				msg.addReceiver(receivingAgent);
-				msg.setContent(createOrderBoxesJSONMessage(((LoadingBayAgent) baseAgent).readyOrderID));
+				msg.setContent(createOrderBoxesJSONMessage(this.orderID));
 				msg.setConversationId("packaged-orders");
 				msg.setPostTimeStamp(System.currentTimeMillis());
 	
@@ -289,8 +293,7 @@ public class LoadingBayAgent extends BaseAgent {
 				updateProductDatabase(boxesMessageContent);
 
 				if (orderProductsReady(orderID)) {
-					((LoadingBayAgent) baseAgent).readyOrderID = orderID;
-					addBehaviour(new PackagingPhaseMessageSender());
+					addBehaviour(new PackagingPhaseMessageSender(orderID));
 				}
 			} else {
 				block();

--- a/src/main/java/org/maas/agents/LoadingBayAgent.java
+++ b/src/main/java/org/maas/agents/LoadingBayAgent.java
@@ -187,9 +187,9 @@ public class LoadingBayAgent extends BaseAgent {
 		protected void findReceiver() {
 			DFAgentDescription template = new DFAgentDescription();
 			ServiceDescription sd = new ServiceDescription();
-			sd.setType("order-aggregator");
-			sd.setName(bakeryGuid+"-order-aggregator");
+			sd.setType(bakeryGuid+"-order-aggregator");
 			template.addServices(sd);
+			
 			try {
 				DFAgentDescription[] result = DFService.search(myAgent, template);
 				if (result.length > 0) {
@@ -224,17 +224,15 @@ public class LoadingBayAgent extends BaseAgent {
 	}
 
 	private class OrderDetailsReceiver extends CyclicBehaviour {
-		private String orderProcessorServiceType;
 		private AID orderProcessor = null;
 		private MessageTemplate mt;
 
 		protected void findOrderProcessor() {
 			DFAgentDescription template = new DFAgentDescription();
 			ServiceDescription sd = new ServiceDescription();
-			orderProcessorServiceType = bakeryGuid+"-OrderProcessor";
-
-			sd.setType(orderProcessorServiceType);
+			sd.setType(bakeryGuid+"-OrderProcessing");
 			template.addServices(sd);
+			
 			try {
 				DFAgentDescription[] result = DFService.search(myAgent, template);
 				if (result.length > 0) {


### PR DESCRIPTION
This includes the following changes to the loading bay interface agent, some of which were discussed and agreed upon with the other team in #103:
- Changing DF service types by prepending the corresponding bakery ID. This is both for registering and for searching for the relevant agents, such that each agent communicates with agents of the appropriate bakery. 
- Fixing the service type used for finding the order processor to match the integrated agent

Note to @HBRS-MAAS/right-brothers: this was merged into the develop branch.

Update:
An additional fix removes a dependency on a class variable for keeping track of the IDs of ready orders