### PR TITLE
Updating documentation: The Proofer receives CFP instead of INFORM

### DIFF
--- a/docs/messages/proofer.md
+++ b/docs/messages/proofer.md
@@ -2,11 +2,15 @@
 
 ## Input Message: Proofing Request
 
-**Peformative**: INFORM
+**Peformative**: CFP
 
-**Sender**: AID of a Dough Manager Agent, which provides the service "Dough-manager"
+**Sender**: AID of a Dough Manager Agent, which provides the service "DoughManager"
+
+Example: "DoughManager_" + bakeryId
 
 **Receiver**: AID of a Proofer Agent, which provides the service "Proofer"
+
+Example: "Proofer_" + bakeryId
 
 **PostTimeStamp**: Current system time
 
@@ -20,8 +24,9 @@
 ```
 {
     "proofingTime": float,
+    "productQuantities": Vector <Integer>
+    "guids": Vector<String>,
     "productType": String,
-    "guids": Vector<String>
 }
 
 ```
@@ -31,16 +36,128 @@
 
 ```
 {
-  "proofingTime": 1,
-  "productType": "Berliner",
-  "guids": [
-    "order-001",
-    "order-002"
-  ]
+   "proofingTime":6.0,
+   "productQuantities":[
+      1,
+      2
+   ],
+   "guids":[
+      "order-001",
+      "order-002"
+   ],
+   "productType":"Bagel"
 }
 
 ```
 
+#### Example of a behaviour to send CFP to the Proofer:
+
+```
+private class RequestProofing extends Behaviour{
+        private String proofingRequest;
+        private boolean proposalReceived = false;
+        private MessageTemplate mt;
+        private int option = 0;
+
+        public RequestProofing(String proofingRequest){
+            this.proofingRequest = proofingRequest;
+        }
+
+        public void action(){
+
+            switch(option){
+                case 0:
+
+                    ACLMessage cfp = new ACLMessage(ACLMessage.CFP);
+
+                    cfp.addReceiver(prooferAgent);
+                    cfp.setContent(proofingRequest);
+                    cfp.setConversationId("proofing-Request");
+                    cfp.setReplyWith("cfp"+System.currentTimeMillis());
+
+                    baseAgent.sendMessage(cfp);
+
+                    // Template to get proposals/refusals
+                    mt = MessageTemplate.and(
+                         MessageTemplate.MatchConversationId("proofing-Request"),
+                         MessageTemplate.MatchInReplyTo(cfp.getReplyWith()));
+
+                    option = 1;
+                    break;
+
+                case 1:
+
+                    ACLMessage reply = baseAgent.receive(mt);
+                    if (reply != null) {
+
+                        if (reply.getPerformative() == ACLMessage.PROPOSE) {
+                            proposalReceived = true;
+                        }
+
+                        option = 2;
+                        messageProcessing.decrementAndGet();
+                    }
+
+                    else {
+                        block();
+                    }
+                    break;
+
+                case 2:
+
+                	ACLMessage msg = new ACLMessage(ACLMessage.ACCEPT_PROPOSAL);
+
+                    if (proposalReceived) {
+
+                        msg.addReceiver(prooferAgent);
+                        msg.setContent(proofingRequest);
+                        msg.setConversationId("proofing-Request");
+                        msg.setReplyWith(proofingRequest + System.currentTimeMillis());
+                        baseAgent.sendMessage(msg);
+
+                    }
+
+                    // Prepare the template to get the msg reply
+                    mt = MessageTemplate.and(MessageTemplate.MatchConversationId("proofing-Request"),
+                    MessageTemplate.MatchInReplyTo(msg.getReplyWith()));
+
+                    option = 3;
+
+                    break;
+
+                case 3:
+
+                    reply = baseAgent.receive(mt);
+                    if (reply != null) {
+                        if (reply.getPerformative() == ACLMessage.INFORM) {
+                            // The proofer confirmed the ACCEPT_PROPOSAL
+
+                        }else {
+                            // The proofer rejected the ACCEPT_PROPOSAL because it is currently busy. Try again.
+
+                                addBehaviour(new RequestProofing(proofingRequest));
+                            }
+                            option = 4;
+                        }
+                        else {
+                            block();
+                        }
+                        break;
+
+                default:
+                    break;
+            }
+        }
+        public boolean done(){
+            if (option == 2 && !proposalReceived) {
+                // The proofer did not send a PROPOSE because it is currently busy. Try again.
+                addBehaviour(new RequestProofing(proofingRequest, batch));
+            }
+            return ((option == 2 && !proposalReceived) || option == 4);
+
+        }
+    }
+```
 
 ## Output Message
 
@@ -48,7 +165,11 @@
 
 **Sender**: AID of a Proofer Agent, which provides the service "Proofer"
 
-**Receiver**: AID of an agent in the Baking Stage. (In our proof of concept the receiver agent provides the service "Baking-interface")
+Example: "Proofer_" + bakeryId
+
+**Receiver**: AID of an agent in the Baking Stage which provides the service "Baking-interface"
+
+Example: "BakingInterface_" + bakeryId
 
 **PostTimeStamp**: Current system time
 
@@ -61,9 +182,9 @@
 
 ```
 {
-    "productType": String,
-    "guids": Vector<String>,
     "productQuantities": Vector <int>
+    "guids": Vector<String>,
+    "productType": String,
 }
 ```
 
@@ -71,11 +192,15 @@
 
 ```
 {
-  "productType": "Berliner",
-  "guids": [
-    "order-001",
-    "order-002"
-  ],
-  "productQuantities":[10,20]
+   "productQuantities":[
+      1,
+      2
+   ],
+   "guids":[
+      "order-001",
+      "order-002"
+   ],
+   "productType":"Bagel"
 }
+
 ```


### PR DESCRIPTION
Updating documentation for the Proofer agent. 
The Proofer agent receives a CFP. 
Including example for sending a CFP.