### PR TITLE
Updated timekeeper to read end time and start to get scenarioDir

### DIFF
--- a/src/main/java/org/maas/Start.java
+++ b/src/main/java/org/maas/Start.java
@@ -77,7 +77,7 @@ public class Start {
         if(packagingStage) {
             Initializer init = new PackagingStageInitializer();
             sb.append(init.initialize(scenarioDirectory));
-            endTime = "002.01.00";
+            endTime = "003.01.00";
         }
         if(deliveryStage) {
 
@@ -119,6 +119,10 @@ public class Start {
                 localPort = args[i+1];
                 ++i;
             }
+            if (args[i].equals("-scenarioDirectory")) {
+                scenarioDirectory = args[i+1];
+                ++i;
+            }
             if (args[i].equals("-customer")) {
                 customerStage = true;
                 noAgentStarting = false;
@@ -154,7 +158,6 @@ public class Start {
             if (args[i].equals("-noTK")) { // no TimeKeeper
                 runTimeKeeper = false;
             }
-
         }
         if (!isHost && (port == null || host == null)) {
             System.out.println("instance is not host and host and port have to be specified!");

--- a/src/main/java/org/maas/agents/TimeKeeper.java
+++ b/src/main/java/org/maas/agents/TimeKeeper.java
@@ -69,7 +69,7 @@ public class TimeKeeper extends Agent{
             endTime = new Time(endTimeString);
         } else {
             scenarioDirectory = "small";
-            endTime = new Time(0,12,0);
+            endTime = new Time(1,12,0);
         }
         this.readSingleTimeStepFromMeta(scenarioDirectory);
 
@@ -95,6 +95,7 @@ public class TimeKeeper extends Agent{
         TypeReference<?> type = new TypeReference<Meta>(){};
         Meta m = JsonConverter.getInstance(fileString, type);
         this.singleTimeStep = m.getTimeStep();
+        this.endTime = new Time(m.getDurationInDays() + 1, 0, 0);
     }
 	
 	protected void takeDown() {


### PR DESCRIPTION
- Timekeeper reads `endTime` from `meta.json` (Solves #127 )
- `Start.java` can read `scenarioDirectory` from command line arguments (Solves #118 )